### PR TITLE
refactor(Zer0Waste#58): refactor usage of List to Set, add getters/setters for promotions in Product and fix edit method

### DIFF
--- a/backend/zerowaste/src/main/java/com/zerowaste/dtos/products/EditProductDTO.java
+++ b/backend/zerowaste/src/main/java/com/zerowaste/dtos/products/EditProductDTO.java
@@ -1,6 +1,7 @@
 package com.zerowaste.dtos.products;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.zerowaste.models.product.ProductCategory;
 import com.zerowaste.utils.validation.ValidEnum.ValidEnum;
@@ -34,5 +35,7 @@ public record EditProductDTO(
     LocalDate expiresAt,
 
     @Min(0)
-    Integer stock
-) {} 
+    Integer stock,
+
+    List<Long> promotionsIds
+) {}

--- a/backend/zerowaste/src/main/java/com/zerowaste/models/product/Product.java
+++ b/backend/zerowaste/src/main/java/com/zerowaste/models/product/Product.java
@@ -40,8 +40,8 @@ public class Product {
     }
 
     @Id
-    @SequenceGenerator(name = "users_id_seq", sequenceName = "users_id_seq", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "users_id_seq")
+    @SequenceGenerator(name = "product_id_seq", sequenceName = "product_id_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "product_id_seq")
     private Long id;
     
     @Column(name = "name", length = 100)
@@ -187,6 +187,13 @@ public class Product {
         this.deletedAt = deletedAt;
     }
 
+    public void setPromotions(Set<Promotion> promotions2) {
+        if (promotions2 == null) {
+            throw new IllegalArgumentException("Promoções não podem ser nulas.");
+        }
+        this.promotions = Collections.unmodifiableSet(promotions2);
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -210,5 +217,5 @@ public class Product {
         } else if (!id.equals(other.id))
             return false;
         return true;
-    }
+    }   
 }

--- a/backend/zerowaste/src/main/java/com/zerowaste/services/products/ProductService.java
+++ b/backend/zerowaste/src/main/java/com/zerowaste/services/products/ProductService.java
@@ -3,6 +3,8 @@ package com.zerowaste.services.products;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -10,7 +12,9 @@ import org.springframework.stereotype.Service;
 import com.zerowaste.dtos.products.EditProductDTO;
 import com.zerowaste.models.product.Product;
 import com.zerowaste.models.product.ProductCategory;
+import com.zerowaste.models.promotion.Promotion;
 import com.zerowaste.repositories.ProductsRepository;
+import com.zerowaste.repositories.PromotionsRepository;
 import com.zerowaste.services.products.exceptions.ProductNotFoundException;
 
 @Service
@@ -18,6 +22,9 @@ public class ProductService {
     
     @Autowired
     private ProductsRepository productsRepository;
+
+    @Autowired
+    private PromotionsRepository promotionsRepository;
 
     public List<Product> getAll () {
         return productsRepository.findAllNotDeleted();
@@ -32,10 +39,10 @@ public class ProductService {
     }
 
     public void edit (Long id, EditProductDTO dto) throws ProductNotFoundException {
+
+        validateProduct(id, dto);
+
         Product p = productsRepository.findById(id).get();
-        
-        if(p == null || p.getDeletedAt() != null)
-            throw new ProductNotFoundException("Produto não encontrado");
         
         p.setName(dto.name());
         p.setDescription(dto.description());
@@ -46,18 +53,49 @@ public class ProductService {
         p.setExpiresAt(dto.expiresAt());
         p.setStock(dto.stock());
         p.setUpdatedAt(LocalDate.now());
+    
+        
+        if (dto.promotionsIds() != null && !dto.promotionsIds().isEmpty()) {
+            Set<Promotion> promotions = promotionsRepository.findAllById(dto.promotionsIds())
+                                                        .stream()
+                                                        .collect(Collectors.toSet());
+            p.setPromotions(promotions);
+        }
 
         productsRepository.save(p);
+    }
+
+    private void validateProduct(Long id, EditProductDTO dto) throws ProductNotFoundException {
+
+        Product p = productsRepository.findById(id)
+            .orElseThrow(() -> new ProductNotFoundException("Produto não encontrado"));
+
+
+        if (p.getDeletedAt() != null) {
+            throw new ProductNotFoundException("Produto foi deletado");
+        }   
+
+    public void validatePromotions(EditProductDTO dto) {
+        if (dto.promotionsIds() != null && !dto.promotionsIds().isEmpty()) {
+            
+            List<Long> invalidIds = dto.promotionsIds().stream()
+                .filter(id -> !promotionsRepository.existsById(id)) 
+                .collect(Collectors.toList());
+                
+            if (!invalidIds.isEmpty()) {
+                throw new IllegalArgumentException("Um ou mais IDs de promoção são inválidos: " + invalidIds);
+            }
+        }
     }
 
     public void delete (Long id) throws ProductNotFoundException {
         Product p = productsRepository.findById(id).get();
 
-        if(p == null || p.getDeletedAt() != null)
+        if(p == null || p.getDeletedAt() != null) {
             throw new ProductNotFoundException("Produto não encontrado");
+        }
 
         p.setDeletedAt(LocalDate.now());
-        
         productsRepository.save(p);
     }
 }

--- a/backend/zerowaste/src/main/java/com/zerowaste/services/products/ProductService.java
+++ b/backend/zerowaste/src/main/java/com/zerowaste/services/products/ProductService.java
@@ -73,7 +73,8 @@ public class ProductService {
 
         if (p.getDeletedAt() != null) {
             throw new ProductNotFoundException("Produto foi deletado");
-        }   
+        }
+    }  
 
     public void validatePromotions(EditProductDTO dto) {
         if (dto.promotionsIds() != null && !dto.promotionsIds().isEmpty()) {


### PR DESCRIPTION
Este PR aborda as seguintes alterações:

### Alterações principais:

* A sugestão foi substituir o uso de `List` por `Set`, garantindo que não haja IDs de promoção duplicados.
* Foram adicionados os métodos getter e setter padrão para a propriedade `promotions` em `Product`.
* O método `edit` foi corrigido para garantir o manuseio adequado das atualizações e validações do produto.
* A validação dos dados foi corrigida.
* Melhorias foram feitas no uso de coleções e o código foi simplificado para melhorar a legibilidade.

### Tipo de mudança:
* [ ] Correção de bug
* [ ] Nova funcionalidade
* [x] Alteração de funcionalidade existente
* [x] Refatoração

### Checklist:
* [x] O código segue as boas práticas estabelecidas.
* [ ] Testes foram escritos/adaptados para a mudança.
* [x] A documentação foi atualizada.
* [x] O PR foi testado localmente.
