### PR TITLE
Fix: BroadcastType class name

### DIFF
--- a/backend/zerowaste/src/main/java/com/zerowaste/models/broadcast/BroadcastListSendType.java
+++ b/backend/zerowaste/src/main/java/com/zerowaste/models/broadcast/BroadcastListSendType.java
@@ -1,12 +1,12 @@
 package com.zerowaste.models.broadcast;
 
-public enum BroadcastType {
+public enum BroadcastListSendType {
     MANUAL("MANUAL"),
     INTERVAL("INTERVAL");
 
     private final String value;
 
-    BroadcastType(String value) {
+    BroadcastListSendType(String value) {
         this.value = value;
     }
 


### PR DESCRIPTION
Este PR corrige o nome da classe `BroadcastType`, o qual o nome do arquivo .java continha um nome diferente. Esta mudança foi feita utilizando o comando F2 do teclado para que o nome fosse automaticamente atualizado onde quer que ele tenha sido chamada.

### Alterações principais

* Atualiza o nome da classe `BroadcastType` para `BroadcastListSendType`.

### Tipo de mudança

* [x] Bugfix
* [ ] Nova funcionalidade
* [ ] Alteração de funcionalidade existente
* [ ] Refatoração

### Checklist

* [x] Código segue as boas práticas estabelecidas.
* [ ] Testes foram escritos/adaptados para a mudança.
* [x] Documentação foi atualizada.
* [x] O PR foi testado localmente.